### PR TITLE
feat: add no-op setAuthMode function for interface compatibility

### DIFF
--- a/components/auth-context.tsx
+++ b/components/auth-context.tsx
@@ -55,8 +55,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(false);
   // State: authentication mode (always 'dummy' in this version)
   const [authMode] = useState<'real' | 'dummy'>('dummy');
-  // Setter for authMode (no-op, always dummy)
-// Removed the no-op setAuthMode function
+  // Setter for authMode (no-op, always defined to avoid runtime errors)
+  const setAuthMode = (_mode: 'real' | 'dummy') => {
+    // No operation in demo mode; provided for interface compatibility
+  };
   // Router (not used, but kept for interface compatibility)
   const router = useRouter();
 


### PR DESCRIPTION
This pull request modifies the `AuthProvider` component in `components/auth-context.tsx` to improve interface compatibility and prevent potential runtime errors.

### Changes to `AuthProvider`:

* Reintroduced the `setAuthMode` function as a no-op to ensure it is always defined, avoiding runtime errors and maintaining interface compatibility. This function accepts a mode (`'real'` or `'dummy'`) but performs no operation in the current demo mode.